### PR TITLE
Update to the latest libdragon source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [3.0.0] - 2019-11-02
+
+### Changed
+
+- Fixed vand opcode (https://github.com/DragonMinded/libdragon/pull/86)
+- Reimplement mtc2/mfc2 with the extended syntax allowed by RSP (https://github.com/DragonMinded/libdragon/pull/89)
+- Improve error message when using MIPS opcodes not available on RSP (https://github.com/DragonMinded/libdragon/pull/90)
+
+### Added
+
+- Transfer Pak support (https://github.com/DragonMinded/libdragon/pull/88)
+
 ## [2.0.5] - 2019-07-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "description": "This is a docker wrapper for libdragon",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- Fixed vand opcode
- Reimplement mtc2/mfc2 with the extended syntax allowed by RSP
- Improve error message when using MIPS opcodes not available on RSP
- Transfer Pak support