### PR TITLE
Fix double newline on libdragon make

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ function runCommand(cmd) {
     });
 
     command.stdout.on('data', function (data) {
-      console.log(data.toString());
+      process.stdout.write(data.toString());
     });
 
     command.stderr.on('data', function (data) {
-      console.error(data.toString());
+      process.stderr.write(data.toString());
     });
   });
 }


### PR DESCRIPTION
console.log always appends a newline, which usually doubles the newline already sent by the child process.
This means that all output of libdragon make is currently vertically doubled.